### PR TITLE
Add React date picker extension boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# QlikSense_date_Picker
+# QlikSense Date Picker Extension
+
+This repository contains a boilerplate Qlik Sense extension that demonstrates how to use React with a date picker component.
+
+## Structure
+
+```
+react-date-picker-ext/
+  ├── react-date-picker-ext.qext   - Extension metadata
+  └── ReactDatePicker.js           - Main extension script
+```
+
+## Usage
+
+1. Copy the `react-date-picker-ext` folder to your Qlik Sense extensions directory.
+2. Add the extension to a sheet. When loaded, it fetches React, ReactDOM and `react-datepicker` from a CDN and renders a simple date picker.
+
+No build step is required; the extension loads dependencies directly from the web.

--- a/react-date-picker-ext/ReactDatePicker.js
+++ b/react-date-picker-ext/ReactDatePicker.js
@@ -1,0 +1,61 @@
+define([], function () {
+    function loadScript(src) {
+        return new Promise(function (resolve, reject) {
+            if (document.querySelector('script[src="' + src + '"]')) {
+                resolve();
+                return;
+            }
+            var s = document.createElement('script');
+            s.src = src;
+            s.onload = resolve;
+            s.onerror = reject;
+            document.head.appendChild(s);
+        });
+    }
+
+    function loadCss(href) {
+        if (!document.querySelector('link[href="' + href + '"]')) {
+            var l = document.createElement('link');
+            l.rel = 'stylesheet';
+            l.href = href;
+            document.head.appendChild(l);
+        }
+    }
+
+    function renderReact($element) {
+        if (!window.React || !window.ReactDOM || !window.ReactDatePicker) {
+            return;
+        }
+        var container = $element[0];
+        if (!container) {
+            return;
+        }
+        function App() {
+            var _React = window.React,
+                useState = _React.useState,
+                createElement = _React.createElement;
+            var _useState = useState(new Date()),
+                startDate = _useState[0],
+                setStartDate = _useState[1];
+            return createElement(window.ReactDatePicker.default || window.ReactDatePicker, {
+                selected: startDate,
+                onChange: function (date) { return setStartDate(date); }
+            });
+        }
+        window.ReactDOM.render(window.React.createElement(App), container);
+    }
+
+    return {
+        paint: function ($element) {
+            var scripts = [
+                loadScript('https://unpkg.com/react@17/umd/react.development.js'),
+                loadScript('https://unpkg.com/react-dom@17/umd/react-dom.development.js'),
+                loadScript('https://unpkg.com/react-datepicker/dist/react-datepicker.min.js')
+            ];
+            loadCss('https://unpkg.com/react-datepicker/dist/react-datepicker.css');
+            Promise.all(scripts).then(function () {
+                renderReact($element);
+            });
+        }
+    };
+});

--- a/react-date-picker-ext/react-date-picker-ext.qext
+++ b/react-date-picker-ext/react-date-picker-ext.qext
@@ -1,0 +1,8 @@
+{
+  "name": "React Date Picker Extension",
+  "description": "Qlik Sense extension boilerplate using React with a date picker",
+  "version": "0.1.0",
+  "author": "Codex AI",
+  "type": "visualization",
+  "icon": "extension"
+}


### PR DESCRIPTION
## Summary
- add React Qlik Sense extension example using a CDN React date picker
- document usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686507c135bc8332840b4ce880e8100f